### PR TITLE
mmseqs output parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv_win/
 
 # Spyder project settings
 .spyderproject
@@ -128,3 +129,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .Rproj.user
+
+# pycharm
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ which pip
 pip install -r requirements.txt
 ```
 
+6. You might need to add this directory to the `PYTHONPATH` (because Rob is too lazy to add a `setup.py` file)
+
+```
+export PYTHONPATH=$PYTHONPATH:$PWD
+```
+
 You are up and running!
 
 # Collaboration rules!

--- a/hackathon_lib/__init__.py
+++ b/hackathon_lib/__init__.py
@@ -1,0 +1,1 @@
+from .blast import stream_blast_results

--- a/hackathon_lib/blast.py
+++ b/hackathon_lib/blast.py
@@ -1,0 +1,71 @@
+"""
+Parse a blast file and create a blast result object
+"""
+
+import os
+import sys
+import argparse
+import gzip
+
+class BlastResult():
+    def __init__(self, query, db, percent_id, alignment_length, gaps, mismatches, query_start, query_end, db_start, db_end,
+                 evalue, bitscore, query_length=None, subject_length=None):
+        self.query = query
+        self.db = db
+        self.alignment_length = int(alignment_length)
+        self.percent_id = float(percent_id)
+        self.gaps = int(gaps)
+        self.mismatches = int(mismatches)
+        self.query_start = int(query_start)
+        self.query_end = int(query_end)
+        self.db_start = int(db_start)
+        self.db_end = int(db_end)
+        self.evalue = float(evalue)
+        self.bitscore = float(bitscore)
+        if query_length:
+            self.query_length = int(query_length)
+        if subject_length:
+            self.subject_length = int(subject_length)
+
+    def is_significant(self):
+        """
+        Is this hit significant
+        :return: boolean
+        """
+
+        return self.evalue < 1e-5
+
+    def __str__(self):
+        return "\t".join(map(str, self.query, self.db, self.alignment_length, self.percent_id, self.gaps,
+                             self.mismatches, self.query_start, self.query_end, self.db_start, self.db_end,
+                             self.evalue, self.bitscore, self.query_length, self.subject_length))
+
+def stream_blast_results(blastf, verbose=False):
+    """
+    Parse a tab-separated blast file and stream the results
+    :param blastf: the file to stream
+    :return: a stream of BlastResults
+    """
+
+    if blastf.endswith('.gz'):
+        qin = gzip.open(blastf, 'rt')
+    else:
+        qin = open(blastf, 'r')
+
+    while True:
+        l = qin.readline()
+        if not l:
+            break
+        p = l.strip().split("\t")
+        #if verbose:
+        #    sys.stderr.write("LINE: {}\n".format(p))
+        br = BlastResult(*p)
+        yield br
+
+    return None
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument('-f', help='')
+    parser.add_argument('-v', help='verbose output', action="store_true")
+    args = parser.parse_args()

--- a/hackathon_lib/blast.py
+++ b/hackathon_lib/blast.py
@@ -24,8 +24,12 @@ class BlastResult():
         self.bitscore = float(bitscore)
         if query_length:
             self.query_length = int(query_length)
+        else:
+            self.query_length = None
         if subject_length:
             self.subject_length = int(subject_length)
+        else:
+            self.subject_length = None
 
     def is_significant(self):
         """
@@ -36,9 +40,11 @@ class BlastResult():
         return self.evalue < 1e-5
 
     def __str__(self):
-        return "\t".join(map(str, self.query, self.db, self.alignment_length, self.percent_id, self.gaps,
-                             self.mismatches, self.query_start, self.query_end, self.db_start, self.db_end,
-                             self.evalue, self.bitscore, self.query_length, self.subject_length))
+        output =  "\t".join(map(str, [self.query, self.db, self.alignment_length, self.percent_id, self.gaps, self.mismatches, self.query_start, self.query_end, self.db_start, self.db_end, self.evalue, self.bitscore]))
+        
+        if self.query_length and self.subject_lenth:
+            output = f"{output}\t{self.query_length}\t{self.subject_length}"
+        return output
 
 def stream_blast_results(blastf, verbose=False):
     """

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -22,7 +22,7 @@ def non_overlapping_mmseqs(m8file, mineval, verbose=False):
         if r.evalue > mineval:
             continue
         if r.query != last_query:
-            if not hits:
+            if verbose and last_query and not hits:
                 print(f"There were no hits for {last_query}", file=sys.stderr)
             for h in hits:
                 print(str(h))

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -60,6 +60,4 @@ if __name__ == "__main__":
     parser.add_argument('-v', help='verbose output', action='store_true')
     args = parser.parse_args()
 
-    print(f"E valu: {args.e}", file=sys.stderr)
-
     non_overlapping_mmseqs(args.f, args.e, args.v)

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -1,0 +1,56 @@
+"""
+Parse mmseqs hits and report those that don't overlap the hit with the lowest e-value
+"""
+
+import os
+import sys
+import argparse
+from hackathon_lib import stream_blast_results
+
+__author__ = 'Rob Edwards'
+
+
+def non_overlapping_mmseqs(m8file, mineval, verbose=False):
+    """
+    Find non-overlapping hits
+    """
+
+    hits = []
+    last_query =  None
+    positions = set()
+    for r in stream_blast_results(m8file, verbose):
+        if r.evalue > mineval:
+            continue
+        if r.query != last_query:
+            if not hits:
+                print(f"There were no hits for {last_query}", file=sys.stderr)
+            print(map(str, hits))
+            hits = []
+            positions = set()
+            last_query = r.query
+        keep = True
+        for i in range(r.query_start, r.query_end + 1):
+            if i in positions:
+                keep = False
+        if keep:
+            for i in range(r.query_start, r.query_end + 1):
+                positions.add(i)
+                hits.append(r)
+    print(map(str, hits))
+
+
+
+
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Parse m8 format mmseqs results')
+    parser.add_argument('-f', help='mmseqs m8 format output file', required=True)
+    parser.add_argument('-e', help=f'minimum e value [Default: %(default)f]', default=1e-5, type=float)
+    parser.add_argument('-v', help='verbose output', action='store_true')
+    args = parser.parse_args()
+
+    print(f"E valu: {args.e}", file=sys.stderr)
+
+    non_overlapping_mmseqs(args.f, args.e, args.v)

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -17,7 +17,7 @@ def non_overlapping_mmseqs(m8file, mineval, verbose=False):
 
     hits = []
     last_query =  None
-    positions = set()
+    positions = {}
     for r in stream_blast_results(m8file, verbose):
         if r.evalue > mineval:
             continue
@@ -27,19 +27,23 @@ def non_overlapping_mmseqs(m8file, mineval, verbose=False):
             for h in hits:
                 print(str(h))
             hits = []
-            positions = set()
+            positions = {}
             last_query = r.query
-        keep = True
+
         qsta = r.query_start
         qend = r.query_end
         if qsta > qend:
             (qend, qsta) = (qsta, qend)
+        keep = True
         for i in range(qsta, qend + 1):
             if i in positions:
                 keep = False
+                if r.evalue < positions[i].evalue:
+                    print(f"We had a hit for {positions[i].query} -> {positions[i].db} : {positions[i].evalue} and now",
+                          f" {r.query} -> {r.db} : {r.evalue}", file=sys.stderr)
         if keep:
             for i in range(qsta, qend + 1):
-                positions.add(i)
+                positions[i] = r
             hits.append(r)
     print(list(map(str, hits)))
 

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -24,19 +24,24 @@ def non_overlapping_mmseqs(m8file, mineval, verbose=False):
         if r.query != last_query:
             if not hits:
                 print(f"There were no hits for {last_query}", file=sys.stderr)
-            print(map(str, hits))
+            for h in hits:
+                print(str(h))
             hits = []
             positions = set()
             last_query = r.query
         keep = True
-        for i in range(r.query_start, r.query_end + 1):
+        qsta = r.query_start
+        qend = r.query_end
+        if qsta > qend:
+            (qend, qsta) = (qsta, qend)
+        for i in range(qsta, qend + 1):
             if i in positions:
                 keep = False
         if keep:
-            for i in range(r.query_start, r.query_end + 1):
+            for i in range(qsta, qend + 1):
                 positions.add(i)
-                hits.append(r)
-    print(map(str, hits))
+            hits.append(r)
+    print(list(map(str, hits)))
 
 
 

--- a/parse_m8/non_overlapping_mmseqs_hits.py
+++ b/parse_m8/non_overlapping_mmseqs_hits.py
@@ -10,9 +10,13 @@ from hackathon_lib import stream_blast_results
 __author__ = 'Rob Edwards'
 
 
-def non_overlapping_mmseqs(m8file, mineval, verbose=False):
+def non_overlapping_mmseqs(m8file: str, mineval: float, evalue_check: bool = False, verbose: bool = False):
     """
     Find non-overlapping hits
+    :param m8file: the mmseqs2 m8-format output file
+    :param mineval: the minimum evalue
+    :param evalue_check: check whether discarded hits have a better e value than stored hits
+    :param verbose: more output
     """
 
     hits = []
@@ -38,9 +42,10 @@ def non_overlapping_mmseqs(m8file, mineval, verbose=False):
         for i in range(qsta, qend + 1):
             if i in positions:
                 keep = False
-                if r.evalue < positions[i].evalue:
-                    print(f"We had a hit for {positions[i].query} -> {positions[i].db} : {positions[i].evalue} and now",
-                          f" {r.query} -> {r.db} : {r.evalue}", file=sys.stderr)
+                if evalue_check:
+                    if r.evalue < positions[i].evalue:
+                        print(f"We had a hit for {positions[i].query} -> {positions[i].db} : {positions[i].evalue} and now",
+                              f" {r.query} -> {r.db} : {r.evalue}", file=sys.stderr)
         if keep:
             for i in range(qsta, qend + 1):
                 positions[i] = r
@@ -57,7 +62,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Parse m8 format mmseqs results')
     parser.add_argument('-f', help='mmseqs m8 format output file', required=True)
     parser.add_argument('-e', help=f'minimum e value [Default: %(default)f]', default=1e-5, type=float)
+    parser.add_argument('-c', help='Check whether better e values are discarded', action='store_true')
     parser.add_argument('-v', help='verbose output', action='store_true')
     args = parser.parse_args()
 
-    non_overlapping_mmseqs(args.f, args.e, args.v)
+    non_overlapping_mmseqs(args.f, args.e, args.c, args.v)


### PR DESCRIPTION
Merging in code to parse m8 format and only write non-overlapping hits. If you add `-c` flag, it will check for sequences with a better (lower) `E value` that will be discarded.